### PR TITLE
Enhance admin UI with dashboard layout

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -25,27 +25,39 @@ export default function LoginPage() {
   };
 
   return (
-    <form onSubmit={handleLogin} className="max-w-sm mx-auto mt-20 space-y-4">
-      <input
-        type="email"
-        placeholder="Email"
-        required
-        className="w-full border px-4 py-2"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        required
-        className="w-full border px-4 py-2"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      {error && <p className="text-red-500">{error}</p>}
-      <button className="w-full bg-blue-600 text-white py-2 rounded">
-        Login
-      </button>
-    </form>
+    <div className="grid min-h-screen md:grid-cols-2">
+      <div className="flex items-center justify-center p-8">
+        <form onSubmit={handleLogin} className="w-full max-w-sm space-y-4">
+          <h1 className="text-2xl font-bold text-center">Admin Login</h1>
+          <input
+            type="email"
+            placeholder="Email"
+            required
+            className="w-full border px-4 py-2 text-black"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            required
+            className="w-full border px-4 py-2 text-black"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button className="w-full bg-blue-600 text-white py-2 rounded">
+            Login
+          </button>
+        </form>
+      </div>
+      <div className="hidden md:flex flex-col justify-center bg-gray-900 p-10 text-gray-300">
+        <h2 className="text-3xl font-bold mb-4">WorldBridge Mobile</h2>
+        <p>
+          Access your dashboard from anywhere with our mobile app. Review and
+          verify reports on the go while staying in sync with the admin portal.
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,34 @@
+import { getCurrentAdmin } from "@/lib/auth";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const admin = await getCurrentAdmin();
+
+  return (
+    <div className="flex min-h-screen bg-gray-950 text-gray-100">
+      <aside className="w-56 bg-gray-900 p-4 space-y-4">
+        <h2 className="text-xl font-bold mb-4">Reports</h2>
+        <nav className="space-y-2">
+          <Link className="block hover:underline" href="/dashboard?tab=unverified">
+            Unverified Reports
+          </Link>
+          <Link className="block hover:underline" href="/dashboard?tab=verified">
+            Verified Reports
+          </Link>
+        </nav>
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <header className="bg-gray-800 px-6 py-4 flex justify-between items-center">
+          <span>{admin?.email ?? "Admin"}</span>
+          <Link href="/logout" className="underline">Log out</Link>
+        </header>
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { supabase } from "@/lib/supabaseClient";
 
 async function fetchReports() {
@@ -38,32 +39,37 @@ export default async function DashboardPage() {
   const { approved, unapproved } = await fetchReports();
 
   return (
-    <div className="p-6">
+    <div className="space-y-8">
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
 
-      <section className="mb-8">
-        <h2 className="text-xl font-semibold mb-2">Unapproved Reports</h2>
-        <ul className="space-y-2">
+      <section id="unverified" className="space-y-4">
+        <h2 className="text-xl font-semibold">Unverified Reports</h2>
+        <div className="space-y-2">
           {unapproved.map((r) => (
-            <li key={`${r.id}-${r.type}`}>
-              <Link
-                href={`/reports/${r.type}/${r.id}`}
-                className="text-blue-600 underline"
-              >
-                {r.title}
-              </Link>
-            </li>
+            <Card key={`${r.id}-${r.type}`}>
+              <CardHeader>
+                <CardTitle>
+                  <Link href={`/reports/${r.type}/${r.id}`} className="hover:underline">
+                    {r.title}
+                  </Link>
+                </CardTitle>
+              </CardHeader>
+            </Card>
           ))}
-        </ul>
+        </div>
       </section>
 
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Approved Reports</h2>
-        <ul className="space-y-2">
+      <section id="verified" className="space-y-4">
+        <h2 className="text-xl font-semibold">Verified Reports</h2>
+        <div className="space-y-2">
           {approved.map((r) => (
-            <li key={`${r.id}-${r.type}`}>{r.title}</li>
+            <Card key={`${r.id}-${r.type}`}>
+              <CardHeader>
+                <CardTitle>{r.title}</CardTitle>
+              </CardHeader>
+            </Card>
           ))}
-        </ul>
+        </div>
       </section>
     </div>
   );

--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -3,5 +3,5 @@ import { redirect } from "next/navigation";
 
 export default function LogoutPage() {
   logoutAdmin();
-  redirect("/login");
+  redirect("/admin");
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,46 +10,48 @@ export default function LandingPage() {
       <Header />
       <main className="container mx-auto px-4 py-20 space-y-20">
         <section className="text-center space-y-6">
-          <h1 className="text-4xl font-bold">Welcome to Shadcn Landing</h1>
-          <p className="text-muted-foreground">Build beautiful UIs with Next.js and shadcn/ui.</p>
-          <Button size="lg">Get Started</Button>
+          <h1 className="text-4xl font-bold">WorldBridge Mobile</h1>
+          <p className="text-muted-foreground">
+            Manage incident reports from anywhere with our mobile companion app.
+          </p>
+          <Button size="lg">Download Now</Button>
         </section>
         <section id="features" className="grid md:grid-cols-3 gap-6">
           <Card className="text-center">
             <CardHeader>
-              <CardTitle>Easy to Use</CardTitle>
-              <CardDescription>Components built with Tailwind CSS</CardDescription>
+              <CardTitle>Manage On&nbsp;the&nbsp;Go</CardTitle>
+              <CardDescription>Review reports from your phone</CardDescription>
             </CardHeader>
             <CardContent className="pt-0">
-              Create consistent interfaces quickly.
+              Stay connected even when you&#39;re away from the desk.
             </CardContent>
           </Card>
           <Card className="text-center">
             <CardHeader>
-              <CardTitle>Responsive</CardTitle>
-              <CardDescription>Works on all devices</CardDescription>
+              <CardTitle>Realtime Alerts</CardTitle>
+              <CardDescription>Get notified instantly</CardDescription>
             </CardHeader>
             <CardContent className="pt-0">
-              Layout adapts to any screen size.
+              Receive push notifications for new reports.
             </CardContent>
           </Card>
           <Card className="text-center">
             <CardHeader>
-              <CardTitle>Open Source</CardTitle>
-              <CardDescription>MIT licensed components</CardDescription>
+              <CardTitle>Secure Access</CardTitle>
+              <CardDescription>Your data is protected</CardDescription>
             </CardHeader>
             <CardContent className="pt-0">
-              Customize them to fit your needs.
+              Built with modern security best practices.
             </CardContent>
           </Card>
         </section>
         <section id="about" className="space-y-4">
           <h2 className="text-2xl font-bold">About</h2>
-          <p>Shadcn Landing is a demo project using shadcn/ui with Next.js 15.</p>
+          <p>WorldBridge Mobile complements this admin portal, allowing field agents to submit and track reports effortlessly.</p>
         </section>
         <section id="contact" className="space-y-4">
           <h2 className="text-2xl font-bold">Contact</h2>
-          <p>Email us at contact@example.com.</p>
+          <p>Reach us at support@worldbridge.app.</p>
         </section>
       </main>
       <Footer />

--- a/src/app/reports/[type]/[id]/page.tsx
+++ b/src/app/reports/[type]/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabaseClient";
+import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function ReportDetail({ params }: any) {
@@ -21,15 +22,21 @@ export default async function ReportDetail({ params }: any) {
   );
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-6">
       <h1 className="text-2xl font-bold">Report Details</h1>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {filtered.map(([key, value]) => (
-          <div key={key}>
-            <strong className="capitalize">{key.replace(/_/g, " ")}:</strong>
-            <p className="text-gray-800">{value?.toString() || "N/A"}</p>
-          </div>
+          <Card key={key}>
+            <CardHeader>
+              <CardTitle className="capitalize">
+                {key.replace(/_/g, " ")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p>{value?.toString() || "N/A"}</p>
+            </CardContent>
+          </Card>
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- update landing page copy to promote the mobile app
- redesign admin login with two-column layout and promo text
- add dashboard layout with sidebar and top navigation
- list reports in cards and show details using cards
- fix logout path

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b777c7c4883269f79203793b5b5ce