### PR TITLE
Add report search and user management fixes

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,12 +5,12 @@ import { supabase } from "@/lib/supabaseClient";
 async function fetchReports() {
     const { data: business } = await supabase
       .from("business_reports")
-      .select("*, userdetails(username, id), created_at")
+      .select("*, userdetails(username, id), categories(initials), created_at")
       .eq("is_draft", false);
 
     const { data: individual } = await supabase
       .from("individual_reports")
-      .select("*, userdetails(username, id), created_at")
+      .select("*, userdetails(username, id), categories(initials), created_at")
       .eq("is_draft", false);
 
     const taggedBusiness = (business ?? []).map((r) => ({

--- a/src/app/profile/[id]/ban/route.ts
+++ b/src/app/profile/[id]/ban/route.ts
@@ -1,0 +1,29 @@
+import { supabase } from "@/lib/supabaseClient";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { data, error } = await supabase
+    .from("userdetails")
+    .select("is_banned")
+    .eq("id", params.id)
+    .single();
+
+  if (error || !data) {
+    return new Response("User not found", { status: 404 });
+  }
+
+  const { error: updateError } = await supabase
+    .from("userdetails")
+    .update({ is_banned: !data.is_banned })
+    .eq("id", params.id);
+
+  if (updateError) {
+    return new Response("Failed to update", { status: 500 });
+  }
+
+  redirect(`/profile/${params.id}`);
+}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,4 +1,6 @@
 import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@radix-ui/themes";
 import { supabase } from "@/lib/supabaseClient";
 
 interface Params {
@@ -48,6 +50,14 @@ export default async function UserProfile({ params }: Params) {
 
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-6 bg-gray-950 text-gray-100 min-h-screen">
+      <Button color="red">
+        <Link
+          href="/dashboard?tab=users"
+          className="inline-flex items-center gap-2 text-sm"
+        >
+          ← Back
+        </Link>
+      </Button>
       <h1 className="text-2xl font-bold">{user.username ?? "User"}</h1>
       {user.avatar_url && (
         <Image
@@ -76,6 +86,17 @@ export default async function UserProfile({ params }: Params) {
           </p>
         )}
       </div>
+      <form action={`/profile/${id}/ban`} method="POST">
+        <button
+          className={`px-4 py-2 rounded text-white ${
+            user.is_banned
+              ? "bg-green-600 hover:bg-green-500"
+              : "bg-red-600 hover:bg-red-500"
+          }`}
+        >
+          {user.is_banned ? "Unban User" : "Ban User"}
+        </button>
+      </form>
     </div>
   );
 }

--- a/src/app/reports/[type]/[id]/media/[mediaId]/unverify/route.ts
+++ b/src/app/reports/[type]/[id]/media/[mediaId]/unverify/route.ts
@@ -1,0 +1,19 @@
+import { supabase } from "@/lib/supabaseClient";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { type: string; id: string; mediaId: string } }
+) {
+  const { error } = await supabase
+    .from("report_media")
+    .update({ media_verify: false })
+    .eq("report_media_id", params.mediaId);
+
+  if (error) {
+    return new Response("Failed to unverify media", { status: 500 });
+  }
+
+  redirect(`/reports/${params.type}/${params.id}`);
+}

--- a/src/app/reports/[type]/[id]/media/[mediaId]/verify/route.ts
+++ b/src/app/reports/[type]/[id]/media/[mediaId]/verify/route.ts
@@ -1,0 +1,19 @@
+import { supabase } from "@/lib/supabaseClient";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { type: string; id: string; mediaId: string } }
+) {
+  const { error } = await supabase
+    .from("report_media")
+    .update({ media_verify: true })
+    .eq("report_media_id", params.mediaId);
+
+  if (error) {
+    return new Response("Failed to verify media", { status: 500 });
+  }
+
+  redirect(`/reports/${params.type}/${params.id}`);
+}

--- a/src/app/reports/[type]/[id]/page.tsx
+++ b/src/app/reports/[type]/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function ReportDetail({
       *,
       userdetails(username, id),
       categories(initials),
-      report_media(media_url, media_type),
+      report_media(report_media_id, media_url, media_type, media_verify),
       comments(id),
       republish_reports(id),
       likes(id)
@@ -157,34 +157,63 @@ export default async function ReportDetail({
             Attached Media
           </h2>
           <div className="flex flex-wrap gap-4">
-            {report.report_media.map((m: string, idx: number) => {
-              const folder = m.media_type?.startsWith("video")
-                ? "postVideos"
-                : "postImages";
-              const mediaUrl = m.media_url.startsWith("http")
-                ? m.media_url
-                : `https://gdhndglrjbuojsgcziyg.supabase.co/storage/v1/object/public/uploads/${folder}/${m.media_url}`;
+            {report.report_media.map(
+              (
+                m: {
+                  report_media_id: number;
+                  media_type: string;
+                  media_url: string;
+                  media_verify: boolean;
+                }
+              ) => {
+                const folder = m.media_type?.startsWith("video")
+                  ? "postVideos"
+                  : "postImages";
+                const mediaUrl = m.media_url.startsWith("http")
+                  ? m.media_url
+                  : `https://gdhndglrjbuojsgcziyg.supabase.co/storage/v1/object/public/uploads/${folder}/${m.media_url}`;
+                const action = m.media_verify ? "unverify" : "verify";
 
-              return m.media_type.startsWith("image") ? (
-                <Image
-                  key={idx}
-                  src={mediaUrl}
-                  alt="Media"
-                  width={256}
-                  height={192}
-                  className="object-cover rounded border border-gray-700"
-                />
-              ) : (
-                <video
-                  key={idx}
-                  controls
-                  className="w-64 h-48 rounded bg-black border border-gray-700"
-                >
-                  <source src={mediaUrl} type="video/mp4" />
-                  Your browser does not support the video tag.
-                </video>
-              );
-            })}
+                return (
+                  <div
+                    key={m.report_media_id}
+                    className="flex flex-col items-start gap-2"
+                  >
+                    {m.media_type.startsWith("image") ? (
+                      <Image
+                        src={mediaUrl}
+                        alt="Media"
+                        width={256}
+                        height={192}
+                        className="object-cover rounded border border-gray-700"
+                      />
+                    ) : (
+                      <video
+                        controls
+                        className="w-64 h-48 rounded bg-black border border-gray-700"
+                      >
+                        <source src={mediaUrl} type="video/mp4" />
+                        Your browser does not support the video tag.
+                      </video>
+                    )}
+                    <form
+                      action={`/reports/${type}/${id}/media/${m.report_media_id}/${action}`}
+                      method="POST"
+                    >
+                      <button
+                        className={`px-2 py-1 rounded text-white ${
+                          m.media_verify
+                            ? "bg-red-600 hover:bg-red-500"
+                            : "bg-green-600 hover:bg-green-500"
+                        }`}
+                      >
+                        {m.media_verify ? "Unverify" : "Verify"}
+                      </button>
+                    </form>
+                  </div>
+                );
+              }
+            )}
           </div>
         </div>
       )}

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -5,15 +5,16 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
-  interface Report {
-    id: number;
-    type: "business" | "individual";
-    title: string;
-    incident_details?: string | null;
-    verified: boolean;
-    created_at: string;
-    userdetails?: { username?: string; id?: string };
-  }
+interface Report {
+  id: number;
+  type: "business" | "individual";
+  title: string;
+  incident_details?: string | null;
+  verified: boolean;
+  created_at: string;
+  userdetails?: { username?: string; id?: string };
+  categories?: { initials?: string };
+}
 
 interface DashboardClientProps {
   data: {
@@ -31,14 +32,16 @@ export default function DashboardClient({ data, tab }: DashboardClientProps) {
   const [verifiedPage, setVerifiedPage] = useState(1);
   const router = useRouter();
 
-    const filterByQuery = (r: Report) => {
-      const query = searchQuery.toLowerCase();
-      return (
-        r.title.toLowerCase().includes(query) ||
-        (r.incident_details ?? "").toLowerCase().includes(query) ||
-        r.id.toString().includes(query)
-      );
-    };
+  const filterByQuery = (r: Report) => {
+    const query = searchQuery.toLowerCase();
+    const reportNumber = `${r.categories?.initials ?? ""}-${r.type[0].toUpperCase()}-${r.id}`;
+    return (
+      r.title.toLowerCase().includes(query) ||
+      (r.incident_details ?? "").toLowerCase().includes(query) ||
+      r.id.toString().includes(query) ||
+      reportNumber.toLowerCase().includes(query)
+    );
+  };
 
   const sortByDateDesc = (a: Report, b: Report) =>
     new Date(b.created_at).getTime() - new Date(a.created_at).getTime();

--- a/src/components/UsersClient.tsx
+++ b/src/components/UsersClient.tsx
@@ -86,7 +86,7 @@ export default function UsersClient({ users }: { users: User[] }) {
       </div>
 
       <div className="overflow-x-auto max-h-[500px] rounded-lg border border-gray-700">
-        <table className="w-full text-sm bg-gray-900 min-w-max">
+        <table className="w-full text-sm bg-gray-900 table-fixed">
           <thead className="bg-gray-800 text-left text-gray-300">
             <tr>
               {columns.map((col) => (
@@ -105,7 +105,7 @@ export default function UsersClient({ users }: { users: User[] }) {
                 {columns.map((col) => (
                   <td
                     key={col.key as string}
-                    className="p-3 whitespace-nowrap"
+                    className="p-3 break-words"
                   >
                     {getValue(user, col.key)}
                   </td>


### PR DESCRIPTION
## Summary
- enable searching reports by formatted report number
- fix users table overflow with fixed layout
- add user profile back button, ban/unban action, and media verification controls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68924fcd5ee483269705fe150709e67d