### PR TITLE
Fix report media id field

### DIFF
--- a/src/app/reports/[type]/[id]/media/[mediaId]/unverify/route.ts
+++ b/src/app/reports/[type]/[id]/media/[mediaId]/unverify/route.ts
@@ -9,7 +9,7 @@ export async function POST(
   const { error } = await supabase
     .from("report_media")
     .update({ media_verify: false })
-    .eq("report_media_id", params.mediaId);
+    .eq("id", params.mediaId);
 
   if (error) {
     return new Response("Failed to unverify media", { status: 500 });

--- a/src/app/reports/[type]/[id]/media/[mediaId]/verify/route.ts
+++ b/src/app/reports/[type]/[id]/media/[mediaId]/verify/route.ts
@@ -9,7 +9,7 @@ export async function POST(
   const { error } = await supabase
     .from("report_media")
     .update({ media_verify: true })
-    .eq("report_media_id", params.mediaId);
+    .eq("id", params.mediaId);
 
   if (error) {
     return new Response("Failed to verify media", { status: 500 });

--- a/src/app/reports/[type]/[id]/page.tsx
+++ b/src/app/reports/[type]/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function ReportDetail({
       *,
       userdetails(username, id),
       categories(initials),
-      report_media(report_media_id, media_url, media_type, media_verify),
+      report_media(id, media_url, media_type, media_verify),
       comments(id),
       republish_reports(id),
       likes(id)
@@ -160,7 +160,7 @@ export default async function ReportDetail({
             {report.report_media.map(
               (
                 m: {
-                  report_media_id: number;
+                  id: number;
                   media_type: string;
                   media_url: string;
                   media_verify: boolean;
@@ -176,7 +176,7 @@ export default async function ReportDetail({
 
                 return (
                   <div
-                    key={m.report_media_id}
+                    key={m.id}
                     className="flex flex-col items-start gap-2"
                   >
                     {m.media_type.startsWith("image") ? (
@@ -197,7 +197,7 @@ export default async function ReportDetail({
                       </video>
                     )}
                     <form
-                      action={`/reports/${type}/${id}/media/${m.report_media_id}/${action}`}
+                      action={`/reports/${type}/${id}/media/${m.id}/${action}`}
                       method="POST"
                     >
                       <button


### PR DESCRIPTION
## Summary
- query report media using `id` instead of non-existent `report_media_id`
- use `id` when verifying or unverifying media entries

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68925384e83883269b9dde86d751a49b