### PR TITLE
Simplify users table and add user profile page

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,0 +1,109 @@
+import { supabase } from "@/lib/supabaseClient";
+import Link from "next/link";
+import { Button } from "@radix-ui/themes";
+
+interface ProfilePageProps {
+  params: { id: string };
+}
+
+async function fetchUser(id: string) {
+  const { data, error } = await supabase
+    .from("userdetails")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!data || error) {
+    return null;
+  }
+
+  const interestIds = data.interests ?? [];
+  const languageIds = data.language_interest ?? [];
+
+  const interestNames: Record<string, string> = {};
+  if (interestIds.length) {
+    const { data: interests } = await supabase
+      .from("interests")
+      .select("id, name")
+      .in("id", interestIds);
+    interests?.forEach((i) => {
+      interestNames[i.id] = i.name;
+    });
+  }
+
+  const languageNames: Record<string, string> = {};
+  if (languageIds.length) {
+    const { data: languages } = await supabase
+      .from("languages")
+      .select("id, name")
+      .in("id", languageIds);
+    languages?.forEach((l) => {
+      languageNames[l.id] = l.name;
+    });
+  }
+
+  return {
+    ...data,
+    interests: interestIds.map((id: string) => interestNames[id] ?? id),
+    language_interest: languageIds.map((id: string) => languageNames[id] ?? id),
+  };
+}
+
+export default async function UserProfilePage({ params }: ProfilePageProps) {
+  const user = await fetchUser(params.id);
+
+  if (!user) {
+    return (
+      <p className="text-red-500 text-center">User not found or failed to load.</p>
+    );
+  }
+
+  const infoFields = [
+    { label: "Username", value: user.username },
+    { label: "Email", value: user.email },
+    { label: "Phone", value: user.phone },
+    { label: "First Name", value: user.first_name },
+    { label: "Last Name", value: user.last_name },
+    { label: "Interests", value: (user.interests ?? []).join(", ") },
+    {
+      label: "Languages",
+      value: (user.language_interest ?? []).join(", "),
+    },
+    { label: "About", value: user.about },
+    { label: "Occupation", value: user.occupation },
+    { label: "Area of Expertise", value: user.area_of_expertise },
+    { label: "Tagline", value: user.tagline },
+    { label: "Country", value: user.country },
+    { label: "State", value: user.state },
+    { label: "City", value: user.city },
+    {
+      label: "Created At",
+      value: new Date(user.created_at).toLocaleString(),
+    },
+  ];
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto space-y-6 bg-gray-950 text-gray-100 min-h-screen">
+      <Button color="red">
+        <Link href="/dashboard" className="inline-flex items-center gap-2 text-sm">
+          ← Back to Dashboard
+        </Link>
+      </Button>
+
+      <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 space-y-4">
+        <h1 className="text-2xl font-bold text-white">User Profile</h1>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {infoFields.map((field) => (
+            <div key={field.label}>
+              <p className="text-sm text-gray-500">{field.label}</p>
+              <p className="text-base font-medium text-gray-100">
+                {field.value ?? "N/A"}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/UsersClient.tsx
+++ b/src/components/UsersClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 interface User {
   id: string;
@@ -22,24 +23,12 @@ interface User {
   city: string | null;
 }
 
+// Display only a small subset of user information in the table
 const columns: { key: keyof User; label: string }[] = [
-  { key: "id", label: "ID" },
   { key: "username", label: "Username" },
   { key: "email", label: "Email" },
   { key: "phone", label: "Phone" },
   { key: "created_at", label: "Created At" },
-  { key: "interests", label: "Interests" },
-  { key: "language_interest", label: "Language Interest" },
-  { key: "first_name", label: "First Name" },
-  { key: "last_name", label: "Last Name" },
-  { key: "avatar_url", label: "Avatar URL" },
-  { key: "about", label: "About" },
-  { key: "occupation", label: "Occupation" },
-  { key: "area_of_expertise", label: "Area of Expertise" },
-  { key: "tagline", label: "Tagline" },
-  { key: "country", label: "Country" },
-  { key: "state", label: "State" },
-  { key: "city", label: "City" },
 ];
 
 function getValue(user: User, key: keyof User) {
@@ -53,6 +42,7 @@ function getValue(user: User, key: keyof User) {
 
 export default function UsersClient({ users }: { users: User[] }) {
   const [searchQuery, setSearchQuery] = useState("");
+  const router = useRouter();
   const filtered = users.filter(
     (u) =>
       (u.username || "").toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -88,7 +78,8 @@ export default function UsersClient({ users }: { users: User[] }) {
             {filtered.map((user) => (
               <tr
                 key={user.id}
-                className="border-t border-gray-800 hover:bg-gray-800 transition"
+                onClick={() => router.push(`/profile/${user.id}`)}
+                className="cursor-pointer border-t border-gray-800 hover:bg-gray-800 transition"
               >
                 {columns.map((col) => (
                   <td


### PR DESCRIPTION
## Summary
- limit users dashboard table to core fields
- make each user row open that user’s profile page
- add dynamic profile page to view full user details

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937eeac5f483269fa5192eb9cb38a0