### PR TITLE
feat: ban users via rpc

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@radix-ui/themes";
 import BanUserButton from "@/components/BanUserButton";
+import UnbanUserButton from "@/components/UnbanUserButton";
 
 interface ProfilePageProps {
   params: { id: string };
@@ -102,9 +103,10 @@ export default async function UserProfilePage({ params }: ProfilePageProps) {
             className="rounded-full object-cover w-24 h-24"
           />
           <h1 className="text-2xl font-bold text-white">User Profile</h1>
-          <div className="ml-auto">
-            <BanUserButton userId={user.id} />
-          </div>
+            <div className="ml-auto flex gap-2">
+              <BanUserButton userId={user.id} />
+              <UnbanUserButton userId={user.id} />
+            </div>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {infoFields.map((field) => (

--- a/src/app/profile/[id]/unban/route.ts
+++ b/src/app/profile/[id]/unban/route.ts
@@ -5,7 +5,7 @@ export async function POST(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const { error } = await supabase.rpc("admin_ban_user", { user_id: params.id });
+  const { error } = await supabase.rpc("admin_unban_user", { user_id: params.id });
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/components/UnbanUserButton.tsx
+++ b/src/components/UnbanUserButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@radix-ui/themes";
+
+export default function UnbanUserButton({ userId }: { userId: string }) {
+  const handleUnban = async () => {
+    const res = await fetch(`/profile/${userId}/unban`, { method: "POST" });
+    if (res.ok) {
+      alert("User unbanned successfully");
+    } else {
+      const data = await res.json().catch(() => null);
+      alert(data?.error || "Failed to unban user");
+    }
+  };
+
+  return (
+    <Button color="green" onClick={handleUnban}>
+      Unban User
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- call Supabase RPC functions to ban and unban users without needing the service role key
- remove unused Supabase admin client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965bfa7c9883269c5dc1b91ad7c272