### PR TITLE
feat: add report search on dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,12 +5,12 @@ import { supabase } from "@/lib/supabaseClient";
 async function fetchReports() {
   const { data: business } = await supabase
     .from("business_reports")
-    .select("*, userdetails(username), created_at")
+    .select("*, userdetails(username), categories(initials), created_at")
     .eq("is_draft", false);
 
   const { data: individual } = await supabase
     .from("individual_reports")
-    .select("*, userdetails(username), created_at")
+    .select("*, userdetails(username), categories(initials), created_at")
     .eq("is_draft", false);
 
   const taggedBusiness = (business ?? []).map((r) => ({
@@ -18,6 +18,8 @@ async function fetchReports() {
     type: "business",
     id: r.business_report_id,
     title: r.report_header,
+    name: r.business_name,
+    reportNumber: `${r.categories?.initials ?? "###"}-B-${r.business_report_id}`,
   }));
 
   const taggedIndividual = (individual ?? []).map((r) => ({
@@ -25,6 +27,8 @@ async function fetchReports() {
     type: "individual",
     id: r.individual_report_id,
     title: r.report_header,
+    name: r.full_name,
+    reportNumber: `${r.categories?.initials ?? "###"}-I-${r.individual_report_id}`,
   }));
 
   const combine = <T extends { verified: boolean }>(items: T[]) => ({

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@radix-ui/themes";
 import BanUserButton from "@/components/BanUserButton";
+import UnbanUserButton from "@/components/UnbanUserButton";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
 
 interface ProfilePageProps {
   params: { id: string };
@@ -60,6 +62,10 @@ export default async function UserProfilePage({ params }: ProfilePageProps) {
     );
   }
 
+  const { data: authData } = await supabaseAdmin.auth.admin.getUserById(params.id);
+  const bannedUntil = authData.user?.banned_until as string | null;
+  const isBanned = !!bannedUntil && new Date(bannedUntil) > new Date();
+
   const infoFields = [
     { label: "Username", value: user.username },
     { label: "Email", value: user.email },
@@ -85,28 +91,34 @@ export default async function UserProfilePage({ params }: ProfilePageProps) {
   ];
 
   return (
-    <div className="p-6 max-w-3xl mx-auto space-y-6 bg-gray-950 text-gray-100 min-h-screen">
-      <Button color="red" className="mb-4">
+    <div className="p-8 max-w-4xl mx-auto space-y-8 bg-gray-950 text-gray-100 min-h-screen">
+      <Button asChild color="red" variant="outline">
         <Link href="/dashboard" className="inline-flex items-center gap-2 text-sm">
           ← Back to Dashboard
         </Link>
       </Button>
 
-      <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 space-y-4">
-        <div className="flex items-center gap-4">
+      <div className="bg-gray-900 border border-gray-800 rounded-xl shadow-lg overflow-hidden">
+        <div className="flex items-center gap-6 p-6 border-b border-gray-800">
           <Image
             src={user.avatar_url || "/branding.svg"}
             alt="Profile image"
             width={96}
             height={96}
-            className="rounded-full object-cover w-24 h-24"
+            className="rounded-full object-cover w-24 h-24 border border-gray-700"
           />
-          <h1 className="text-2xl font-bold text-white">User Profile</h1>
-          <div className="ml-auto">
-            <BanUserButton userId={user.id} />
+          <div>
+            <h1 className="text-2xl font-bold text-white">
+              {user.username || `${user.first_name} ${user.last_name}` || "User Profile"}
+            </h1>
+            <p className="text-gray-400">{user.email}</p>
+          </div>
+          <div className="ml-auto flex gap-2">
+            <BanUserButton userId={user.id} banned={isBanned} />
+            <UnbanUserButton userId={user.id} banned={isBanned} />
           </div>
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-6">
           {infoFields.map((field) => (
             <div key={field.label}>
               <p className="text-sm text-gray-500">{field.label}</p>

--- a/src/app/profile/[id]/unban/route.ts
+++ b/src/app/profile/[id]/unban/route.ts
@@ -8,7 +8,7 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   const { error } = await supabaseAdmin.auth.admin.updateUserById(params.id, {
-    ban_duration: "8760h",
+    ban_duration: "none",
   });
 
   if (error) {

--- a/src/app/reports/[type]/[id]/page.tsx
+++ b/src/app/reports/[type]/[id]/page.tsx
@@ -152,10 +152,8 @@ export default async function ReportDetail({
       </div>
 
       {report.report_media?.length > 0 && (
-        <div className="bg-gray-900 border border-gray-800 rounded-lg p-6">
-          <h2 className="text-lg font-semibold text-white mb-4">
-            Attached Media
-          </h2>
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-white">Attached Media</h2>
           <div className="flex flex-wrap gap-4">
             {report.report_media.map((m: string, idx: number) => {
               const folder = m.media_type?.startsWith("video")
@@ -186,6 +184,14 @@ export default async function ReportDetail({
               );
             })}
           </div>
+          <form
+            action={`/reports/${type}/${id}/verify-media?state=${report.media_verified}`}
+            method="POST"
+          >
+            <button className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded">
+              {report.media_verified ? "Unverify Media" : "Verify Media"}
+            </button>
+          </form>
         </div>
       )}
 

--- a/src/app/reports/[type]/[id]/verify-media/route.ts
+++ b/src/app/reports/[type]/[id]/verify-media/route.ts
@@ -1,0 +1,28 @@
+import { supabase } from "@/lib/supabaseClient";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { params }: any
+) {
+  const table =
+    params.type === "business" ? "business_reports" : "individual_reports";
+  const idColumn =
+    params.type === "business" ? "business_report_id" : "individual_report_id";
+
+  const { searchParams } = new URL(request.url);
+  const current = searchParams.get("state") === "true";
+
+  const { error } = await supabase
+    .from(table)
+    .update({ media_verified: !current })
+    .eq(idColumn, params.id);
+
+  if (error) {
+    return new Response("Failed to update media verification", { status: 500 });
+  }
+
+  redirect(`/reports/${params.type}/${params.id}`);
+}

--- a/src/components/BanUserButton.tsx
+++ b/src/components/BanUserButton.tsx
@@ -2,11 +2,17 @@
 
 import { Button } from "@radix-ui/themes";
 
-export default function BanUserButton({ userId }: { userId: string }) {
+interface BanUserButtonProps {
+  userId: string;
+  banned: boolean;
+}
+
+export default function BanUserButton({ userId, banned }: BanUserButtonProps) {
   const handleBan = async () => {
     const res = await fetch(`/profile/${userId}/ban`, { method: "POST" });
     if (res.ok) {
       alert("User banned successfully");
+      window.location.reload();
     } else {
       const data = await res.json().catch(() => null);
       alert(data?.error || "Failed to ban user");
@@ -14,7 +20,11 @@ export default function BanUserButton({ userId }: { userId: string }) {
   };
 
   return (
-    <Button color="red" onClick={handleBan}>
+    <Button
+      color={banned ? "gray" : "red"}
+      onClick={handleBan}
+      disabled={banned}
+    >
       Ban User
     </Button>
   );

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -10,6 +10,8 @@ interface Report {
   title: string;
   verified: boolean;
   created_at: string;
+  name?: string;
+  reportNumber?: string;
   userdetails?: { username?: string };
 }
 
@@ -29,17 +31,26 @@ export default function DashboardClient({ data, tab }: DashboardClientProps) {
   const [verifiedPage, setVerifiedPage] = useState(1);
   const router = useRouter();
 
-  const filterByTitle = (r: Report) =>
-    r.title.toLowerCase().includes(searchQuery.toLowerCase());
+  const filterByQuery = (r: Report) => {
+    const query = searchQuery.toLowerCase();
+    const fields = [
+      r.title,
+      r.name,
+      r.reportNumber,
+      r.userdetails?.username,
+      String(r.id),
+    ].filter(Boolean) as string[];
+    return fields.some((f) => f.toLowerCase().includes(query));
+  };
 
   const sortByDateDesc = (a: Report, b: Report) =>
     new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
 
   const unverifiedFiltered = data.unapproved
-    .filter(filterByTitle)
+    .filter(filterByQuery)
     .sort(sortByDateDesc);
   const verifiedFiltered = data.approved
-    .filter(filterByTitle)
+    .filter(filterByQuery)
     .sort(sortByDateDesc);
 
   const totalUnverifiedPages = Math.ceil(unverifiedFiltered.length / PAGE_SIZE);
@@ -102,7 +113,7 @@ export default function DashboardClient({ data, tab }: DashboardClientProps) {
       <div className="mb-6">
         <input
           type="text"
-          placeholder="Search reports by title..."
+          placeholder="Search by title, name, report number, or user..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="w-full md:w-1/2 px-4 py-2 rounded bg-gray-800 text-white border border-gray-700 placeholder-gray-400"

--- a/src/components/UnbanUserButton.tsx
+++ b/src/components/UnbanUserButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@radix-ui/themes";
+
+interface UnbanUserButtonProps {
+  userId: string;
+  banned: boolean;
+}
+
+export default function UnbanUserButton({ userId, banned }: UnbanUserButtonProps) {
+  const handleUnban = async () => {
+    const res = await fetch(`/profile/${userId}/unban`, { method: "POST" });
+    if (res.ok) {
+      alert("User unbanned successfully");
+      window.location.reload();
+    } else {
+      const data = await res.json().catch(() => null);
+      alert(data?.error || "Failed to unban user");
+    }
+  };
+
+  return (
+    <Button
+      color={banned ? "green" : "gray"}
+      onClick={handleUnban}
+      disabled={!banned}
+    >
+      Unban User
+    </Button>
+  );
+}

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_KEY;
+
+if (!serviceKey) {
+  throw new Error(
+    "NEXT_PUBLIC_SUPABASE_SERVICE_KEY is required for server-side operations",
+  );
+}
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});


### PR DESCRIPTION
## Summary
- disable ban button and enable unban based on server-side ban status
- restyle the user profile page with a card layout and clearer heading
- rename Supabase service environment variable for admin client
- enable dashboard search across report title, name, report number, or user
- allow admins to verify or unverify report media

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965bfa7c9883269c5dc1b91ad7c272